### PR TITLE
Add function for custom format + tests

### DIFF
--- a/friendlylog/colored_logger.py
+++ b/friendlylog/colored_logger.py
@@ -50,6 +50,18 @@ class _ColoredFormatter(logging.Formatter):
         return super(_ColoredFormatter, self).format(record)
 
 
+def set_fmt(fmt_string):
+    assert isinstance(fmt_string, str), "fmt_string must be string"
+
+    global inner_formatter
+
+    formatter = _ColoredFormatter(
+        fmt=fmt_string
+    )
+    inner_stream_handler.setFormatter(formatter)
+    inner_formatter = formatter
+
+
 _logger = logging.getLogger("friendlylog.ColoredLogger" + "-" + __name__)
 do_not_propagate(_logger)
 

--- a/friendlylog/simple_logger.py
+++ b/friendlylog/simple_logger.py
@@ -32,6 +32,18 @@ class _SimpleFormatter(logging.Formatter):
         return super(_SimpleFormatter, self).format(record)
 
 
+def set_fmt(fmt_string):
+    assert isinstance(fmt_string, str), "fmt_string must be string"
+
+    global inner_formatter
+
+    formatter = _SimpleFormatter(
+        fmt=fmt_string
+    )
+    inner_stream_handler.setFormatter(formatter)
+    inner_formatter = formatter
+
+
 _logger = logging.getLogger("friendlyLog.SimpleLogger" + "-" + __name__)
 do_not_propagate(_logger)
 
@@ -43,6 +55,7 @@ _formatter = _SimpleFormatter(
 _stream_handler.setFormatter(_formatter)
 _logger.addHandler(_stream_handler)
 _logger.setLevel(logging.DEBUG)
+
 
 
 # Export functions and objects.

--- a/friendlylog/simple_logger.py
+++ b/friendlylog/simple_logger.py
@@ -57,7 +57,6 @@ _logger.addHandler(_stream_handler)
 _logger.setLevel(logging.DEBUG)
 
 
-
 # Export functions and objects.
 inner_logger = _logger  # Don't use this except if you know what you are doing.
 inner_stream_handler = _stream_handler  # Same thing for this object.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ codecov
 coverage
 pytest
 pytest-cov
+unittest2; python_version <= "2.7"

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,11 @@ setup(
         'colored>=1.4.0',
         'six>=1.12.0',
     ],
+    extras_require={
+        ':python_version == "2.7"': [
+            'unittest2',
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 2",

--- a/tests/test_colored_logger.py
+++ b/tests/test_colored_logger.py
@@ -8,6 +8,11 @@ import unittest
 from friendlylog import colored_logger as logger
 from threading import Thread
 
+if six.PY2:
+    import unittest2 as unittest
+else:
+    import unittest
+
 
 # Tests cannot be executed in parallel due to the hack in the setUp method.
 class TestColoredLogger(unittest.TestCase):

--- a/tests/test_simple_logger.py
+++ b/tests/test_simple_logger.py
@@ -3,11 +3,14 @@ import logging
 import random
 import six
 import string
-import unittest
 
 from friendlylog import simple_logger as logger
-
 from threading import Thread
+
+if six.PY2:
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 # Tests cannot be executed in parallel due to the hack in the setUp method.


### PR DESCRIPTION
Fixes #8 

Change List:
  * add a ```set_fmt``` function to the ```simple``` and ```colored``` logger such to set custom formats for the output log message
  * add tests for ```simple``` and ```colored``` logger for testing the functionality